### PR TITLE
Adding support for delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The latest release version of stub-http is hosted on [Clojars](https://clojars.o
   (:require [stub-http.core :refer :all]))
 
 (with-routes! 
-	{"/something" {:status 200 :content-type "application/json" :body (json/generate-string {:hello "world"})}
+	{"/something" {:status 200 :content-type "application/json" :body (json/generate-string {:hello "world"}) :delay 1000}
 	 {:path "/y" :query-params {:q "something"}} {:status 200 :content-type "application/json" :body  (json/generate-string {:hello "brave new world"})}}
 	 ; Do actual HTTP request
 	 )

--- a/test/stub_http/delay_test.clj
+++ b/test/stub_http/delay_test.clj
@@ -1,0 +1,19 @@
+(ns stub-http.delay-test
+  (:require [clojure.test :refer :all]
+            [stub-http.core :refer :all]
+            [cheshire.core :as json]
+            [clj-http.lite.client :as client]))
+
+(defmacro bench
+  ([& forms]
+   `(let [start# (System/currentTimeMillis)]
+      ~@forms
+      (- (System/currentTimeMillis) start#))))
+
+(deftest DelayTest
+  (testing "add delay to response"
+    (with-routes!
+      [body (json/generate-string {:hello "world"})]
+      {"/something" {:status 200 :content-type "application/json"
+                     :body   body :delay 1000}}
+      (is (> (bench (client/get (str uri "/something"))) 1000 )))))


### PR DESCRIPTION
This change adds support for delay in stub-http.

It's useful for resilience and timeouts testing, which can only be achieved through stubing/mocking. 