### PR TITLE
Fix a few minor bugs in stub-http.internal.server/params->map

### DIFF
--- a/src/stub_http/internal/functions.clj
+++ b/src/stub_http/internal/functions.clj
@@ -6,12 +6,6 @@
   fv = the function for the values"
   (into {} (for [[k v] m] [(fk k) (fv v)])))
 
-(defn keywordize-keys
-  "Recursively transforms all map keys from strings to keywords."
-  [m]
-  (let [f (fn [[k v]] (if (string? k) [(keyword k) v] [k v]))]
-    (clojure.walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
-
 (defn substring-before [str before]
   "Return the substring of string <str> before string <before>. If no match then <str> is returned."
   (let [index-of-before (.indexOf str before)]

--- a/src/stub_http/internal/server.clj
+++ b/src/stub_http/internal/server.clj
@@ -1,6 +1,6 @@
 (ns stub-http.internal.server
   (:require [clojure.string :refer [split blank? lower-case]]
-            [stub-http.internal.functions :refer [map-kv keywordize-keys substring-before not-nil?]])
+            [stub-http.internal.functions :refer [map-kv not-nil?]])
   (:import (fi.iki.elonen NanoHTTPD NanoHTTPD$Response$IStatus NanoHTTPD$Response$Status NanoHTTPD$IHTTPSession)
            (java.util HashMap)))
 

--- a/src/stub_http/internal/server.clj
+++ b/src/stub_http/internal/server.clj
@@ -5,17 +5,12 @@
            (java.util HashMap)))
 
 (defn- params->map [param-string]
-  (if-not (blank? param-string)
-    (let [params-splitted-by-ampersand (split param-string #"&")
-          ; Handle no-value parameters. If a no-value parameter is found then use nil as parameter value
-          param-list (mapcat #(let [index-of-= (.indexOf % "=")]
-                                (if (and
-                                      (> index-of-= 0)
-                                      ; Check if the first = char is the last char of the param.
-                                      (< (inc index-of-=) (.length %)))
-                                  (split % #"=")
-                                  [% nil])) params-splitted-by-ampersand)]
-      (keywordize-keys (apply hash-map param-list)))))
+  (when-not (blank? param-string)
+    (->> (split param-string #"&")
+         (map #(split % #"=" 2))
+         (map (fn [[k v]]
+                [(keyword k) (when-not (blank? v) v)]))
+         (into {}))))
 
 (defn- to-str [o]
   (str (if (keyword? o)

--- a/test/stub_http/internal/server_test.clj
+++ b/test/stub_http/internal/server_test.clj
@@ -1,0 +1,15 @@
+(ns stub-http.internal.server-test
+  (:require [clojure.test :refer (are deftest)]
+            [stub-http.internal.server :as server]))
+
+(deftest exercise-params->map
+  (are [input expected]
+       (= expected (#'server/params->map input))
+
+    nil nil
+    "" nil
+    "foo=bar" {:foo "bar"}
+    "foo=bar&baz=quux" {:foo "bar" :baz "quux"}
+    "foo=&baz=quux" {:foo nil :baz "quux"}
+    "foo=bar&baz=" {:foo "bar" :baz nil}
+    "foo=bar=baz&bar=&baz=quux" {:foo "bar=baz" :bar nil :baz "quux"}))


### PR DESCRIPTION
While chasing down a different issue, I spotted some bugs in the implementation of `stub-http.internal.server/params->map` which can be summarised like so:

| Input | Expected Output | Actual Output |
| --- | --- | --- |
| "foo=&baz=quux" | {:foo nil :baz "quux"} | {:foo= nil :baz "quux"} |
| "foo=bar=baz&bar=&baz=quux" | {:foo "bar=baz", :bar nil, :baz "quux"} | IllegalArgumentException |

This PR adds a test to exercise those cases, a fresh implementation of `stub-http.internal.server/params->map` which is not subject to those bugs and a small amount of dead code removal.