### PR TITLE
Remove sources of reflection

### DIFF
--- a/src/stub_http/core.clj
+++ b/src/stub_http/core.clj
@@ -39,7 +39,7 @@
   (recorded-requests [this] "Return all recorded requests")
   (recorded-responses [this] "Return all recorded responses"))
 
-(defrecord NanoFakeServer [nano-server routes]
+(defrecord NanoFakeServer [^NanoHTTPD nano-server routes]
   Closeable
   (close [_]
     (.stop nano-server))

--- a/src/stub_http/internal/functions.clj
+++ b/src/stub_http/internal/functions.clj
@@ -6,7 +6,7 @@
   fv = the function for the values"
   (into {} (for [[k v] m] [(fk k) (fv v)])))
 
-(defn substring-before [str before]
+(defn substring-before [^String str ^String before]
   "Return the substring of string <str> before string <before>. If no match then <str> is returned."
   (let [index-of-before (.indexOf str before)]
     (if (= -1 index-of-before)

--- a/src/stub_http/internal/server.clj
+++ b/src/stub_http/internal/server.clj
@@ -29,9 +29,9 @@
    body - The response body
    delay - Delay in ms added to the response"
   (let [; We see if a predefined status exists for the supplied status code
-        status (first (filter #(= (.getRequestStatus %) status) (NanoHTTPD$Response$Status/values)))
         ; If no match then we create a custom implementation of IStatus with the supplied status
-        status (or status (reify NanoHTTPD$Response$IStatus
+        status (or (NanoHTTPD$Response$Status/lookup status)
+                   (reify NanoHTTPD$Response$IStatus
                             (getDescription [_] "")
                             (getRequestStatus [_]
                               status)))

--- a/src/stub_http/internal/spec.clj
+++ b/src/stub_http/internal/spec.clj
@@ -1,5 +1,6 @@
 (ns stub-http.internal.spec
-  (:require [stub-http.internal.functions :refer [substring-before]])
+  (:require [clojure.string :refer (lower-case)]
+            [stub-http.internal.functions :refer [substring-before]])
   (:import (clojure.lang PersistentArrayMap IPersistentMap IFn Keyword)))
 
 (defn- request-spec-matches? [request-spec request]
@@ -7,7 +8,7 @@
             (substring-before path "?"))
           (method-matches? [expected-method actual-method]
             (let [; Make keyword out of string and never mind "case" of keyword (i.e. :GET and :get are treated the same)
-                  normalize #(->> (if (string? %) % (name %)) .toLowerCase keyword)
+                  normalize (comp keyword lower-case name)
                   expected-normalized (normalize (or expected-method actual-method)) ; Assume same as actual if not present
                   actual-normalized (normalize actual-method)]
               (= expected-normalized actual-normalized)))
@@ -21,7 +22,7 @@
          (query-param-matches? (:query-params request-spec) (:query-params request))
          (method-matches? (:method request-spec) (:method request)))))
 
-(defn- throw-normalization-exception! [type val]
+(defn- throw-normalization-exception! [type ^Object val]
   (let [class-name (-> val .getClass .getName)
         error-message (str "Internal error: Couldn't find " type " conversion strategy for class " (-> val .getClass .getName))]
     (throw (ex-info error-message {:class class-name :value val}))))


### PR DESCRIPTION
Add some type hints so that code using this library doesn't get reflection warnings if they `(set! *warn-on-reflection* true)`.