### PR TITLE
read PUT data from tmp file before it gets deleted

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,8 @@
   :dependencies [[org.nanohttpd/nanohttpd "2.3.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [cheshire "5.5.0"]
-                                  [clj-http-lite "0.3.0"]]}}
+                                  [clj-http-lite "0.3.0"]
+                                  ;; needed for java>=11:
+                                  [javax.xml.bind/jaxb-api "2.3.1"]]}}
   :repositories [["releases" {:url "http://clojars.org/repo" :creds :gpg}]]
   :plugins [[lein-codox "0.9.4"]])

--- a/test/stub_http/recording_test.clj
+++ b/test/stub_http/recording_test.clj
@@ -32,8 +32,7 @@
 
       (is (= "PUT /something HTTP/1.1" (:request-line req3)))
       (is (starts-with? (->> req3 :headers :accept) "application/json"))
-      ;; TODO: "content" is the name of an already deleted tmp file
-      (is (string? (get-in req3 [:body "content"]))))))
+      (is (= "some PUT data" (get-in req3 [:body "content"]))))))
 
 (deftest RecordedResponsesTest
   (with-routes!

--- a/test/stub_http/recording_test.clj
+++ b/test/stub_http/recording_test.clj
@@ -10,15 +10,30 @@
     {"/something" {:status 200 :content-type "application/json"
                    :body   (json/generate-string {:hello "world"})}}
     (client/get (str uri "/something"))
-    (client/get (str uri "/something"))
+    (client/post (str uri "/something")
+                 {:body "{\"this-is\": \"json\"}"
+                  :content-type :json})
+    (client/put (str uri "/something")
+                {:body "some PUT data"
+                 :accept :json})
     (let [requests (recorded-requests server)
-          [req1 req2] requests]
-      (is (= 2 (count requests)))
+          [req1 req2 req3] requests]
+      (is (= 3 (count requests)))
+
+      (is (= "GET /something HTTP/1.1" (:request-line req1)))
       (is (starts-with? (->> req1 :headers :accept) "text/html"))
-      (is (starts-with? (->> req2 :headers :accept) "text/html"))
       (is (false? (contains? req1 :query-params)))
       (is (false? (contains? req1 :body)))
-      (is (= "GET /something HTTP/1.1" (:request-line req2))))))
+
+      (is (= "POST /something HTTP/1.1" (:request-line req2)))
+      (is (starts-with? (->> req2 :headers :accept) "text/html"))
+      (is (= "{\"this-is\": \"json\"}" (get-in req2 [:body "postData"])))
+      (is (starts-with? (get-in req2 [:headers :content-type]) "application/json"))
+
+      (is (= "PUT /something HTTP/1.1" (:request-line req3)))
+      (is (starts-with? (->> req3 :headers :accept) "application/json"))
+      ;; TODO: "content" is the name of an already deleted tmp file
+      (is (string? (get-in req3 [:body "content"]))))))
 
 (deftest RecordedResponsesTest
   (with-routes!


### PR DESCRIPTION
NanoHTTPD shoves PUT body data into a tmp file, which it then deletes
after request has been handled. This means that you'd see a path for a
nonexistent file when looking at a PUT recording.

Slurp the file in session->stub-request to fix this.

See also:
- https://github.com/NanoHttpd/nanohttpd/issues/471
- https://github.com/NanoHttpd/nanohttpd/blob/cd37235110d6712204c77e2bdc463e84af6ed4e3/core/src/main/java/org/nanohttpd/protocols/http/HTTPSession.java#L459