### PR TITLE
Add support for matching request body

### DIFF
--- a/src/stub_http/internal/spec.clj
+++ b/src/stub_http/internal/spec.clj
@@ -17,10 +17,14 @@
           (query-param-matches? [expected-params actual-params]
             (let [expected-params (or expected-params {})   ; Assume empty map if nil
                   query-params-to-match (select-keys actual-params (keys expected-params))]
-              (= expected-params query-params-to-match)))]
+              (= expected-params query-params-to-match)))
+          (body-matches? [expected-body actual-body]
+            (let [expected-body (or expected-body actual-body)]   ; Assume match if empty
+              (= expected-body actual-body)))]
     (and (apply path-matches? (map (comp path-without-query-params :path) [request-spec request]))
          (query-param-matches? (:query-params request-spec) (:query-params request))
-         (method-matches? (:method request-spec) (:method request)))))
+         (method-matches? (:method request-spec) (:method request))
+         (body-matches? (:body request-spec) (get-in request [:body "postData"])))))
 
 (defn- throw-normalization-exception! [type ^Object val]
   (let [class-name (-> val .getClass .getName)

--- a/test/stub_http/body_test.clj
+++ b/test/stub_http/body_test.clj
@@ -1,0 +1,29 @@
+(ns stub-http.body-test
+  (:require [clojure.test :refer :all]
+            [stub-http.core :refer :all]
+            [cheshire.core :as json]
+            [clj-http.lite.client :as client]))
+
+(deftest BodyMatching
+  (testing "routes can match on body"
+    (with-routes!
+      {{:path   "/something"
+        :body   (json/generate-string {:some-property "some-value"})}
+       {:status 201 :content-type "application/json" :body (json/generate-string {:hello "world1"})}
+       {:path   "/something"
+        :body   (json/generate-string {:some-property "different-value"})}
+       {:status 201 :content-type "application/json" :body (json/generate-string {:hello "world2"})}}
+      (let [response1 (->
+                        (str uri "/something")
+                        (client/post {:body         (json/generate-string {:some-property "some-value"})
+                                      :content-type :json})
+                        :body
+                        (json/parse-string true))
+            response2 (->
+                        (str uri "/something")
+                        (client/post {:body         (json/generate-string {:some-property "different-value"})
+                                      :content-type :json})
+                        :body
+                        (json/parse-string true))]
+        (is (= "world1" (:hello response1)))
+        (is (= "world2" (:hello response2)))))))


### PR DESCRIPTION
I'm slightly unsure if the solution for the body matching is generic to all HTTP libraries. The :body from the request returns a map with "postData", which contains the actual request body. If we think this is valid for all cases, then I think we're good to go.